### PR TITLE
Ajuste do texto de uma entrada na timeline

### DIFF
--- a/src/modules/timeline/index.tsx
+++ b/src/modules/timeline/index.tsx
@@ -40,7 +40,7 @@ export function Timeline() {
           variant="light"
         />
         <TimeIntervale
-          label="Início povoamento"
+          label="Início do povoamento"
           start={1462}
           end={1876}
           scale={scale}


### PR DESCRIPTION
"Início povoamento" → "Início do povoamento"